### PR TITLE
fixed tensor device mismatch when using flash_attn

### DIFF
--- a/lmppl/ppl_recurrent_lm.py
+++ b/lmppl/ppl_recurrent_lm.py
@@ -125,7 +125,8 @@ class LM:
                     model_inputs = self.tokenizer(input_texts[s:e], truncation=True, padding=True, return_tensors='pt')
                 if 'token_type_ids' in model_inputs:
                     model_inputs.pop('token_type_ids')
-
+		
+		model_inputs = {k: v.to(self.device) for k, v in model_inputs.items()}
                 output = self.model(**{k: v.to(self.device) for k, v in model_inputs.items()})
                 logit = output['logits']
                 if self.pad_token_initialized:


### PR DESCRIPTION
Fixed device mismatch between input tensors in PyTorch - fixed model_inputs to be on cuda:0 and not cpu. 

Previous error: 
> RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument target in method wrapper_CUDA_nll_loss_forward)